### PR TITLE
Provide more informative error message

### DIFF
--- a/lib/parallel.ml
+++ b/lib/parallel.ml
@@ -242,7 +242,7 @@ let create_client f io =
 
 let process f = match !master with
   | Some t -> create_client f t
-  | None -> failwith "Multiprocessor"
+  | None -> failwith "Multiprocessor - check if init was called"
 
 let run exec =
   let rec child_f (astream,bpush) =


### PR DESCRIPTION
I have a place where I match on Failure and getting this message of just `Multiprocessor` took longer than it should have for me to figure out where the error was, since I was also upgrading libraries at the same time as trying out this lib. 