### PR TITLE
makes tests compatible with 32-bit systems

### DIFF
--- a/lib_test/run_tests.ml
+++ b/lib_test/run_tests.ml
@@ -41,7 +41,7 @@ let setup_log level =
 
 let seed = [| 7; 8; 42; 56 |]
 let tasks = 64
-let task_size = 4096 * 1024
+let task_size = min (4096 * 1024) (Sys.max_array_length / 2)
 let delay = 4. *. atan 1.
 
 let task (data,push) =

--- a/lwt-parallel.opam
+++ b/lwt-parallel.opam
@@ -17,7 +17,7 @@ build: [
 
 depends: [
   "base-unix"
-  "dune"
+  "dune" {>= "1.6"}
   "fmt"
   "logs"
   "lwt"   {>= "2.7.0"}


### PR DESCRIPTION
We hit the maximum array size cap, which is less than 2M in 32-bit systems.